### PR TITLE
replacing rss-parser with feedparser

### DIFF
--- a/index.js
+++ b/index.js
@@ -174,12 +174,14 @@ ControllerPodcast.prototype.addPodcast = function(data) {
       self.getPodcastI18nString('ADD_PODCAST_PROCESSING')
   );
 
-  var headers = {
-    'Accept': '*/*',
-    'User-Agent': 'Mozilla/5.0'
+  var options = {
+    headers: {
+      'Accept': '*/*',
+      'User-Agent': 'Mozilla/5.0'
+    }
   };
 
-  rss.query(rssUrl, headers).then(
+  rss.query(rssUrl, options).then(
     function (feed) {
       var imageUrl = feed.channel.imageUrl;
       var podcastItem = {
@@ -389,12 +391,14 @@ ControllerPodcast.prototype.getPodcastContent = function(uri) {
       message
   );
 
-  var headers = {
-    'Accept': '*/*',
-    'User-Agent': 'Mozilla/5.0'
+  var options = {
+    headers: {
+      'Accept': '*/*',
+      'User-Agent': 'Mozilla/5.0'
+    }
   };
 
-  rss.query(self.podcasts.items[uris[1]].url, headers).then(function (feed) {
+  rss.query(self.podcasts.items[uris[1]].url, options).then(function (feed) {
     response.navigation.lists[0].title = feed.title;
 
     self.currentEpisodes = [];

--- a/package.json
+++ b/package.json
@@ -15,13 +15,13 @@
     "plugin_type": "music_service"
   },
   "dependencies": {
+    "feedparser": "^2.2.9",
     "fs-extra": "^6.0.1",
+    "html-to-json": "^0.6.0",
     "kew": "^0.7.0",
-    "v-conf": "^1.4.2",
-    "rss-parser": "^3.4.2",
     "lodash": "^4.17.10",
     "unirest": "^0.5.1",
-    "html-to-json": "^0.6.0"
+    "v-conf": "^1.4.2"
   },
   "repository": {
     "type": "git",

--- a/rss.js
+++ b/rss.js
@@ -1,0 +1,93 @@
+var libQ = require('kew');
+var zlib = require('zlib');
+var FeedParser = require('feedparser');
+var request = require('request');
+var _ = require('lodash');
+
+function maybeDecompress (res, encoding) {
+  var decompress;
+  if (encoding.match(/\bdeflate\b/)) {
+    decompress = zlib.createInflate();
+  } else if (encoding.match(/\bgzip\b/)) {
+    decompress = zlib.createGunzip();
+  }
+  return decompress ? res.pipe(decompress) : res;
+}
+
+function getParams(str) {
+  var params = str.split(';').reduce(function (params, param) {
+    var parts = param.split('=').map(function (part) { return part.trim(); });
+    if (parts.length === 2) {
+      params[parts[0]] = parts[1];
+    }
+    return params;
+  }, {});
+  return params;
+}
+
+function queryFeed(url, headers, maxItems) {
+  headers = headers || {};
+  maxItems = maxItems || 300;
+  var errored = false;
+  var defer = libQ.defer();
+  var req = request(url)
+  for (var h in headers) {
+    req.setHeader(h, headers[h]);
+  }
+
+  var feedparser = new FeedParser();
+
+  req.on('error', function (error) {
+    errored = true;
+    defer.reject(error);
+  });
+
+  req.on('response', function (res) {
+    if (res.statusCode !== 200) {
+      return this.emit('error', new Error('Bad status code'));
+    }
+    var encoding = res.headers['content-encoding'] || 'identity';
+    var charset = getParams(res.headers['content-type'] || '').charset;
+    res = maybeDecompress(res, encoding);
+    res.pipe(feedparser);
+  });
+
+  feedparser.on('error', function (error) {
+    errored = true;
+    defer.reject(error);
+  });
+
+  var channel = {};
+  feedparser.on('meta', function (meta) {
+    channel.imageUrl = _.get(meta, 'image.url');
+    if (!channel.imageUrl) {
+      channel.imageUrl = _.get(meta, 'itunes:image.@.href');
+    }
+    channel.title = meta.title;
+  });
+
+  var items = [];
+  feedparser.on('readable', function () {
+    var stream = this;
+    var meta = this.meta;
+
+    var item;
+    while (item = stream.read()) {
+      if (items.length < maxItems && _.get(item, 'enclosures[0]')) {
+        items.push(item);
+      }
+    }
+  });
+
+  feedparser.on('end', function() {
+    if (!errored) {
+      defer.resolve({channel: channel, items: items});
+    }
+  });
+
+  return defer.promise;
+}
+
+module.exports = {
+  query: queryFeed  
+}


### PR DESCRIPTION
## Issue

See https://github.com/ChrisPanda/volumio-podcast-plugin/issues/6 for details.

## What?

I replaced `rss-parser` with `feedparser` because it allowed me to get inbetween the request and the parsing. This enabled me to determine if there is `gzip`-compressed content and to actually decompress it.

## Original description

I currently cannot add [this podcast feed](http://www.kakadu.de/podcast-kinderhoerspiel.3420.de.podcast), it ends in [this XML parsing error](https://github.com/isaacs/sax-js/issues/138):

```
Error: Non-whitespace before first tag.
...
```

The HTTP response for the feed returns gzip-ed data. I suspect that the RSS parser tries to decode the compressed response directly into XML. I did a test with the parser on the decompressed data as a string input and it works. A test with the compressed data as a string resulted in the same error as above.

I also tried querying the server with a different `Accept-Encoding` request header but it always returned compressed data.

Here are the response headers:

```
Accept-Ranges: bytes
Age: 942
Cache-Control: public, max-age=60, pre-check=60, no-transform
Connection: keep-alive
Content-Encoding: gzip
Content-Length: 5362
Content-Type: application/xml; charset=utf-8
Date: Wed, 05 Sep 2018 07:01:45 GMT
Expires: Wed, 05 Sep 2018 07:02:45 GMT
Last-modified: Wed, 05 Sep 2018 07:01:46 GMT
P3P: CP="NOI NID ADMa OUR IND UNI COM NAV"
Pragma: 
Vary: Accept-Encoding
X-Cache: HIT
X-Cache-Info: caching
X-Server: webr02
```